### PR TITLE
bootspec: don't generate for containers

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -103,7 +103,9 @@ let
 
       echo -n "${toString config.system.extraDependencies}" > $out/extra-dependencies
 
-      ${bootSpec.writer}
+      ${optionalString (!config.boot.isContainer) ''
+        ${bootSpec.writer}
+      ''}
 
       ${config.system.extraSystemBuilderCmds}
     '';


### PR DESCRIPTION
Avoid dragging in a kernel/initrd/etc in containers (and WSL).
