### PR TITLE
Feature preview: Bootspecs as a NixOS module with tests

### DIFF
--- a/doc/languages-frameworks/cuelang.section.md
+++ b/doc/languages-frameworks/cuelang.section.md
@@ -1,0 +1,93 @@
+# Cue (Cuelang) {#cuelang}
+
+[Cuelang](https://cuelang.org/) is a language to:
+
+- describe schemas and validate backward-compatibility
+- generate code and schemas in various formats (e.g. JSON Schema, OpenAPI)
+- do configuration akin to [Dhall Lang](https://dhall-lang.org/)
+- perform data validation
+
+## Cuelang schema quick start
+
+Cuelang schemas are similar to JSON, here is a quick cheatsheet:
+
+- Default types includes: `null`, `string`, `bool`, `bytes`, `number`, `int`, `float`, lists as `[...T]` where `T` is a type.
+- All structures, defined by: `myStructName: { <fields> }` are **open** -- they accept fields which are not specified.
+- Closed structures can be built by doing `myStructName: close({ <fields> })` -- they are strict in what they accept.
+- `#X` are **definitions**, referenced definitions are **recursively closed**, i.e. all its children structures are **closed**.
+- `&` operator is the [unification operator](https://cuelang.org/docs/references/spec/#unification) (similar to a type-level merging operator), `|` is the [disjunction operator](https://cuelang.org/docs/references/spec/#disjunction) (similar to a type-level union operator).
+- Values **are** types, i.e. `myStruct: { a: 3 }` is a valid type definition that only allows `3` as value.
+
+- Read <https://cuelang.org/docs/concepts/logic/> to learn more about the semantics.
+- Read <https://cuelang.org/docs/references/spec/> to learn about the language specification.
+
+## `writeCueValidator`
+
+Nixpkgs provides a `pkgs.writeCueValidator` helper, which will write a validation script based on the provided Cuelang schema.
+
+Here is an example:
+```
+pkgs.writeCueValidator
+  (pkgs.writeText ''
+    #Def1: {
+      field1: string
+    }
+  '')
+  { document = "#Def1"; }
+```
+
+- The first parameter is the Cue schema file.
+- The second paramter is an options parameter, currently, only: `document` can be passed.
+
+`document` : match your input data against this fragment of structure or definition, e.g. you may use the same schema file but differents documents based on the data you are validating.
+
+Another example, given the following `validator.nix` :
+```
+{ pkgs ? import <nixpkgs> {} }:
+let
+  genericValidator = version: 
+  pkgs.writeCueValidator
+    (pkgs.writeText ''
+      #Version1: {
+        field1: string
+      }
+      #Version2: #Version1 & {
+        field1: "unused"
+      }''
+    )
+    { document = "#Version${toString version}"; };
+in
+{
+  validateV1 = genericValidator 1;
+  validateV2 = genericValidator 2;
+}
+```
+
+The result is a script that will validate the file you pass as the first argument against the schema you provided `writeCueValidator`.
+
+It can be any format that `cue vet` supports, i.e. YAML or JSON for example.
+
+Here is an example, named `example.json`, given the following JSON:
+```
+{ field1: "abc" }
+```
+
+You can run the result script (named `validate`) as the following:
+
+```console
+$ nix-build validator.nix
+$ ./result example.json
+$ ./result-2 example.json
+field1: conflicting values "unused" and "abc":
+    ./example.json:1:13
+    ../../../../../../nix/store/v64dzx3vr3glpk0cq4hzmh450lrwh6sg-schema.cue:5:11
+$ sed -i 's/"abc"/3/' example.json
+$ ./result example.json
+field1: conflicting values 3 and string (mismatched types int and string):
+    ./example.json:1:13
+    ../../../../../../nix/store/v64dzx3vr3glpk0cq4hzmh450lrwh6sg-schema.cue:5:11
+```
+
+**Known limitations**
+
+* The script will enforce **concrete** values and will not accept lossy transformations (strictness). You can add these options if you need them.

--- a/doc/languages-frameworks/index.xml
+++ b/doc/languages-frameworks/index.xml
@@ -13,6 +13,7 @@
  <xi:include href="coq.section.xml" />
  <xi:include href="crystal.section.xml" />
  <xi:include href="cuda.section.xml" />
+ <xi:include href="cuelang.section.xml" />
  <xi:include href="dhall.section.xml" />
  <xi:include href="dotnet.section.xml" />
  <xi:include href="emscripten.section.xml" />

--- a/nixos/doc/manual/development/bootspec.chapter.md
+++ b/nixos/doc/manual/development/bootspec.chapter.md
@@ -1,0 +1,36 @@
+# Experimental feature: Bootspec {#sec-experimental-bootspec}
+
+Bootspec is a experimental feature, introduced in the [RFC-0125 proposal](https://github.com/NixOS/rfcs/125), the reference implementation can be found [there](https://github.com/NixOS/nixpkgs/pull/172237) in order to standardize bootloader support
+and advanced boot workflows such as SecureBoot and potentially more.
+
+You can enable the creation of bootspec documents through [`boot.bootspec.enable = true`](options.html#opt-boot.bootspec.enable), which will prompt a warning until [RFC-0125](https://github.com/NixOS/rfcs/125) is officially merged.
+
+## Schema {#sec-experimental-bootspec-schema}
+
+The bootspec schema is versioned and validated against [a CUE schema file](https://cuelang.org/) which should considered as the source of truth for your applications.
+
+You will find the current version [here](../../../modules/system/activation/bootspec.cue).
+
+## Extensions mechanism {#sec-experimental-bootspec-extensions}
+
+Bootspec cannot account for all usecases.
+
+For this purpose, Bootspec offers a generic extension facility [`boot.bootspec.extensions`](options.html#opt-boot.bootspec.extensions) which can be used to inject any data needed for your usecases.
+
+An example for SecureBoot is to get the Nix store path to `/etc/os-release` in order to bake it into a unified kernel image:
+
+```nix
+{ config, lib, ... }: {
+  boot.bootspec.extensions = {
+    "org.secureboot.osRelease" = config.environment.etc."os-release".source;
+  };
+}
+```
+
+To reduce incompatibility and prevent names from clashing between applications, it is **highly recommended** to use a unique namespace for your extensions.
+
+## External bootloaders {#sec-experimental-bootspec-external-bootloaders}
+
+It is possible to enable your own bootloader through [`boot.loader.external.installHook`](options.html#opt-boot.loader.external.installHook) which can wrap an existing bootloader.
+
+Currently, there is no good story to compose existing bootloaders to enrich their features, e.g. SecureBoot, etc. It will be necessary to reimplement or reuse existing parts.

--- a/nixos/doc/manual/development/development.xml
+++ b/nixos/doc/manual/development/development.xml
@@ -12,6 +12,7 @@
  <xi:include href="../from_md/development/sources.chapter.xml" />
  <xi:include href="../from_md/development/writing-modules.chapter.xml" />
  <xi:include href="../from_md/development/building-parts.chapter.xml" />
+ <xi:include href="../from_md/development/bootspec.chapter.xml" />
  <xi:include href="../from_md/development/what-happens-during-a-system-switch.chapter.xml" />
  <xi:include href="../from_md/development/writing-documentation.chapter.xml" />
  <xi:include href="../from_md/development/nixos-tests.chapter.xml" />

--- a/nixos/doc/manual/from_md/development/bootspec.chapter.xml
+++ b/nixos/doc/manual/from_md/development/bootspec.chapter.xml
@@ -1,0 +1,73 @@
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sec-experimental-bootspec">
+  <title>Experimental feature: Bootspec</title>
+  <para>
+    Bootspec is a experimental feature, introduced in the
+    <link xlink:href="https://github.com/NixOS/rfcs/125">RFC-0125
+    proposal</link>, the reference implementation can be found
+    <link xlink:href="https://github.com/NixOS/nixpkgs/pull/172237">there</link>
+    in order to standardize bootloader support and advanced boot
+    workflows such as SecureBoot and potentially more.
+  </para>
+  <para>
+    You can enable the creation of bootspec documents through
+    <link xlink:href="options.html#opt-boot.bootspec.enable"><literal>boot.bootspec.enable = true</literal></link>,
+    which will prompt a warning until
+    <link xlink:href="https://github.com/NixOS/rfcs/125">RFC-0125</link>
+    is officially merged.
+  </para>
+  <section xml:id="sec-experimental-bootspec-schema">
+    <title>Schema</title>
+    <para>
+      The bootspec schema is versioned and validated against
+      <link xlink:href="https://cuelang.org/">a CUE schema file</link>
+      which should considered as the source of truth for your
+      applications.
+    </para>
+    <para>
+      You will find the current version
+      <link xlink:href="../../../modules/system/activation/bootspec.cue">here</link>.
+    </para>
+  </section>
+  <section xml:id="sec-experimental-bootspec-extensions">
+    <title>Extensions mechanism</title>
+    <para>
+      Bootspec cannot account for all usecases.
+    </para>
+    <para>
+      For this purpose, Bootspec offers a generic extension facility
+      <link xlink:href="options.html#opt-boot.bootspec.extensions"><literal>boot.bootspec.extensions</literal></link>
+      which can be used to inject any data needed for your usecases.
+    </para>
+    <para>
+      An example for SecureBoot is to get the Nix store path to
+      <literal>/etc/os-release</literal> in order to bake it into a
+      unified kernel image:
+    </para>
+    <programlisting language="bash">
+{ config, lib, ... }: {
+  boot.bootspec.extensions = {
+    &quot;org.secureboot.osRelease&quot; = config.environment.etc.&quot;os-release&quot;.source;
+  };
+}
+</programlisting>
+    <para>
+      To reduce incompatibility and prevent names from clashing between
+      applications, it is <emphasis role="strong">highly
+      recommended</emphasis> to use a unique namespace for your
+      extensions.
+    </para>
+  </section>
+  <section xml:id="sec-experimental-bootspec-external-bootloaders">
+    <title>External bootloaders</title>
+    <para>
+      It is possible to enable your own bootloader through
+      <link xlink:href="options.html#opt-boot.loader.external.installHook"><literal>boot.loader.external.installHook</literal></link>
+      which can wrap an existing bootloader.
+    </para>
+    <para>
+      Currently, there is no good story to compose existing bootloaders
+      to enrich their features, e.g. SecureBoot, etc. It will be
+      necessary to reimplement or reuse existing parts.
+    </para>
+  </section>
+</chapter>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1224,6 +1224,7 @@
   ./services/x11/xfs.nix
   ./services/x11/xserver.nix
   ./system/activation/activation-script.nix
+  ./system/activation/bootspec.nix
   ./system/activation/top-level.nix
   ./system/boot/binfmt.nix
   ./system/boot/emergency-mode.nix

--- a/nixos/modules/system/activation/bootspec.cue
+++ b/nixos/modules/system/activation/bootspec.cue
@@ -12,12 +12,6 @@
 	extensions?: {...}
 }
 
-#SecureBootExtensions: #V1 & {
-	extensions: {
-		osRelease: string
-	}
-}
-
 Document: {
 	v1: #V1
 }

--- a/nixos/modules/system/activation/bootspec.cue
+++ b/nixos/modules/system/activation/bootspec.cue
@@ -1,0 +1,23 @@
+#V1: {
+	init:           string
+	initrd?:        string
+	initrdSecrets?: string
+	kernel:         string
+	kernelParams: [...string]
+	label:    string
+	toplevel: string
+	specialisation?: {
+		[=~"^"]: #V1
+	}
+	extensions?: {...}
+}
+
+#SecureBootExtensions: #V1 & {
+	extensions: {
+		osRelease: string
+	}
+}
+
+Document: {
+	v1: #V1
+}

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -38,6 +38,9 @@ let
         ''
           mkdir -p $out/bootspec
 
+          # Inject toplevel and init in the bootspec.
+          # This can be done only here because we *cannot* depend on $out, except
+          # by living in $out itself.
           ${pkgs.jq}/bin/jq '
             .v1.toplevel = $toplevel |
             .v1.init = $init
@@ -47,7 +50,7 @@ let
             --arg init "$out/init" \
             < ${json} \
             | ${pkgs.jq}/bin/jq \
-              --sort-keys \
+              --sort-keys \ # Slurp all specialisations and inject them as values in .specialisations.{name} = {specialisation bootspec}.
               '.v1.specialisation = ($ARGS.named | map_values(. | first | .v1))' \
               ${lib.concatStringsSep " " specialisationLoader} \
             > $out/bootspec/${filename}

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -3,23 +3,31 @@
 # Changes to the structure of the document, or the semantics of the values should go through an RFC.
 #
 # See: https://github.com/NixOS/rfcs/pull/125
-{ config, pkgs, lib, children }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
+  cfg = config.boot.bootspec;
+  children = lib.mapAttrs (childName: childConfig: childConfig.configuration.system.build.toplevel) config.specialisation;
   schemas = {
     v1 = rec {
-      filename = "boot.v1.json";
+      filename = "boot.json";
       json =
         pkgs.writeText filename
           (builtins.toJSON
-            {
-              schemaVersion = 1;
-
+          {
+            v1 = {
               kernel = "${config.boot.kernelPackages.kernel}/${config.system.boot.loader.kernelFile}";
               kernelParams = config.boot.kernelParams;
               initrd = "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}";
               initrdSecrets = "${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets";
               label = "NixOS ${config.system.nixos.codeName} ${config.system.nixos.label} (Linux ${config.boot.kernelPackages.kernel.modDirVersion})";
-            });
+
+              inherit (cfg) extensions;
+            };
+          });
 
       generator =
         let
@@ -31,8 +39,8 @@ let
           mkdir -p $out/bootspec
 
           ${pkgs.jq}/bin/jq '
-            .toplevel = $toplevel |
-            .init = $init
+            .v1.toplevel = $toplevel |
+            .v1.init = $init
             ' \
             --sort-keys \
             --arg toplevel "$out" \
@@ -40,17 +48,50 @@ let
             < ${json} \
             | ${pkgs.jq}/bin/jq \
               --sort-keys \
-              '.specialisation = ($ARGS.named | map_values(. | first))' \
+              '.v1.specialisation = ($ARGS.named | map_values(. | first | .v1))' \
               ${lib.concatStringsSep " " specialisationLoader} \
             > $out/bootspec/${filename}
         '';
+
+      validator = pkgs.writeCueValidator ./bootspec.cue {
+        document = "Document"; # Universal validator for any version as long the schema is correctly set.
+      };
     };
   };
 in
 {
-  # This will be run as a part of the `systemBuilder` in ./top-level.nix. This
-  # means `$out` points to the output of `config.system.build.toplevel` and can
-  # be used for a variety of things (though, for now, it's only used to report
-  # the path of the `toplevel` itself and the `init` executable).
-  writer = schemas.v1.generator;
+  options.boot.bootspec = {
+    enable = lib.mkEnableOption "Enable generation of RFC-0125 bootspec in $system/bootspec, e.g. /run/current-system/bootspec";
+    extensions = lib.mkOption {
+      type = lib.types.attrs;
+      default = {};
+    };
+    # This will be run as a part of the `systemBuilder` in ./top-level.nix. This
+    # means `$out` points to the output of `config.system.build.toplevel` and can
+    # be used for a variety of things (though, for now, it's only used to report
+    # the path of the `toplevel` itself and the `init` executable).
+    writer = lib.mkOption {
+      internal = true;
+      default = schemas.v1.generator;
+    };
+    validator = lib.mkOption {
+      internal = true;
+      default = schemas.v1.validator;
+    };
+    filename = lib.mkOption {
+      internal = true;
+      default = schemas.v1.filename;
+    };
+  };
+
+  config = lib.mkIf (cfg.enable) {
+    warnings = [
+      ''RFC-0125 is not merged yet, this is a feature preview of bootspec.
+        Schema is not definitive and features are not stabilized until RFC-0125 is merged.
+        See:
+        - https://github.com/NixOS/nixpkgs/pull/172237 to track merge status in nixpkgs.
+        - https://github.com/NixOS/rfcs/pull/125 to track RFC status.
+      ''
+    ];
+  };
 }

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -87,7 +87,7 @@ in
   config = lib.mkIf (cfg.enable) {
     warnings = [
       ''RFC-0125 is not merged yet, this is a feature preview of bootspec.
-        Schema is not definitive and features are not stabilized until RFC-0125 is merged.
+        The schema is not definitive and features are not guaranteed to be stable until RFC-0125 is merged.
         See:
         - https://github.com/NixOS/nixpkgs/pull/172237 to track merge status in nixpkgs.
         - https://github.com/NixOS/rfcs/pull/125 to track RFC status.

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -22,14 +22,6 @@ let
         "${config.system.boot.loader.kernelFile}";
       initrdPath = "${config.system.build.initialRamdisk}/" +
         "${config.system.boot.loader.initrdFile}";
-
-      bootSpec = import ./bootspec.nix {
-        inherit
-          config
-          pkgs
-          lib
-          children;
-      };
     in ''
       mkdir $out
 
@@ -104,7 +96,8 @@ let
       echo -n "${toString config.system.extraDependencies}" > $out/extra-dependencies
 
       ${optionalString (!config.boot.isContainer) ''
-        ${bootSpec.writer}
+        ${config.boot.bootspec.writer}
+        ${config.boot.bootspec.validator} "$out/bootspec/${config.boot.bootspec.filename}"
       ''}
 
       ${config.system.extraSystemBuilderCmds}

--- a/nixos/modules/system/boot/loader/external/external.nix
+++ b/nixos/modules/system/boot/loader/external/external.nix
@@ -7,7 +7,7 @@ let
 in
 {
   meta = {
-    maintainers = with maintainers; [ cole-h grahamc ];
+    maintainers = with maintainers; [ cole-h grahamc raitobezarius ];
     # Don't edit the docbook xml directly, edit the md and generate it:
     # `pandoc external.md -t docbook --top-level-division=chapter --extract-media=media -f markdown+smart > external.xml`
     doc = ./external.xml;
@@ -30,7 +30,7 @@ in
     boot.loader = {
       grub.enable = mkDefault false;
       systemd-boot.enable = mkDefault false;
-      supportsInitrdSecrets = false;
+      supportsInitrdSecrets = mkDefault false;
     };
 
     system.build.installBootLoader = cfg.installHook;

--- a/nixos/tests/bootspec.nix
+++ b/nixos/tests/bootspec.nix
@@ -1,0 +1,143 @@
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing-python.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let
+  baseline = {
+    virtualisation.useBootLoader = true;
+  };
+  grub = {
+    boot.loader.grub.enable = true;
+  };
+  systemd-boot = {
+    boot.loader.systemd-boot.enable = true;
+  };
+  uefi = {
+    virtualisation.useEFIBoot = true;
+    boot.loader.efi.canTouchEfiVariables = true;
+    environment.systemPackages = [ pkgs.efibootmgr ];
+  };
+  standard = {
+    boot.bootspec.enable = true;
+
+    imports = [
+      baseline
+      systemd-boot
+      uefi
+    ];
+  };
+in
+{
+  basic = makeTest {
+    name = "systemd-boot-with-bootspec";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = standard;
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("test -e /run/current-system/bootspec/boot.json")
+    '';
+  };
+
+  grub = makeTest {
+    name = "grub-with-bootspec";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = {
+      boot.bootspec.enable = true;
+
+      imports = [
+        baseline
+        grub
+        uefi
+      ];
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("test -e /run/current-system/bootspec/boot.json")
+    '';
+  };
+
+  legacy-boot = makeTest {
+    name = "legacy-boot-with-bootspec";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = {
+      boot.bootspec.enable = true;
+
+      imports = [
+        baseline
+        grub
+      ];
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("test -e /run/current-system/bootspec/boot.json")
+    '';
+  };
+
+  # Check that specialisations create corresponding entries in bootspec.
+  specialisation = makeTest {
+    name = "bootspec-with-specialisation";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = {
+      imports = [ standard ];
+      environment.systemPackages = [ pkgs.jq ];
+      specialisation.something.configuration = {};
+    };
+
+    testScript = ''
+      import json
+
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.succeed("test -e /run/current-system/bootspec/boot.json")
+      machine.succeed("test -e /run/current-system/specialisation/something/bootspec/boot.json")
+
+      sp_in_parent = json.loads(machine.succeed("jq -r '.v1.specialisation.something' /run/current-system/bootspec/boot.json"))
+      sp_in_fs = json.loads(machine.succeed("cat /run/current-system/specialisation/something/bootspec/boot.json"))
+
+      assert sp_in_parent == sp_in_fs['v1'], "Bootspecs of the same specialisation are different!"
+    '';
+  };
+
+  # Check that extensions are propagated.
+  extensions = makeTest {
+    name = "bootspec-with-extensions";
+    meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
+
+    nodes.machine = { config, ... }: {
+      imports = [ standard ];
+      environment.systemPackages = [ pkgs.jq ];
+      boot.bootspec.extensions = {
+        osRelease = config.environment.etc."os-release".source;
+      };
+    };
+
+    testScript = ''
+      machine.start()
+      machine.wait_for_unit("multi-user.target")
+
+      current_os_release = machine.succeed("cat /etc/os-release")
+      bootspec_os_release = machine.succeed("cat $(jq -r '.v1.extensions.osRelease' /run/current-system/bootspec/boot.json)")
+
+      assert current_os_release == bootspec_os_release, "Filename referenced by extension has unexpected contents"
+    '';
+  };
+
+}

--- a/pkgs/development/tools/cue/validator.nix
+++ b/pkgs/development/tools/cue/validator.nix
@@ -1,4 +1,9 @@
 { cue, writeShellScript, lib }:
+# `document` must be a fragment of definition or structure that the input data will be matched against.
+# `document` must exist in the Cue schema file provided (`cueSchemaFile`).
+# The result is a script that can be used to validate the input data (JSON/YAML and more can be supported depending on Cue)
+# against the fragment described by `document` or the whole definition.
+# The script will be strict and enforce concrete values, i.e. partial document are not supported.
 cueSchemaFile: { document ? null }:
   writeShellScript "validate-using-cue"
   ''${cue}/bin/cue \

--- a/pkgs/development/tools/cue/validator.nix
+++ b/pkgs/development/tools/cue/validator.nix
@@ -1,0 +1,12 @@
+{ cue, writeShellScript, lib }:
+cueSchemaFile: { document ? null }:
+  writeShellScript "validate-using-cue"
+  ''${cue}/bin/cue \
+      --all-errors \
+      --strict \
+      vet \
+      --concrete \
+      "$1" \
+      ${cueSchemaFile} \
+      ${lib.optionalString (document != null) "-d \"${document}\""}
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2498,6 +2498,8 @@ with pkgs;
     buildGoModule = buildGo118Module; # tests fail with 1.19
   };
 
+  writeCueValidator = callPackage ../development/tools/cue/validator.nix { };
+
   cuelsp = callPackage ../development/tools/cuelsp {};
 
   cyclone-scheme = callPackage ../development/interpreters/cyclone { };


### PR DESCRIPTION
###### Description of changes

This introduces the minimal required setup to have a feature preview of bootspec (RFC-125) in nixpkgs.

- [x] Experimental flag with `warnings` (?)
- [x] Provide an extension field that can be _extended_
- [x] CUE type specification and trivial builder to verify the contents of a bootspec
- [x] NixOS Tests to use bootspec: generator, extensions, specializations, external installer
- [x] Documentation on bootspec

In a later PR, we can revisit some stuff I suppose, including specific points of the RFC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.11 Release Notes (or backporting 22.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2211-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
